### PR TITLE
Fix backend credentials and region

### DIFF
--- a/.github/workflows/infra-aws.yml
+++ b/.github/workflows/infra-aws.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          aws-region: eu-west-1
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/infra-gcp.yml
+++ b/.github/workflows/infra-gcp.yml
@@ -24,7 +24,10 @@ jobs:
         uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
-        run: terraform init
+        run: |
+          echo '${{ secrets.GCP_CREDENTIALS_JSON }}' > /tmp/gcp-key.json
+          export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json
+          terraform init
         working-directory: gcp
 
       - name: Terraform Validate

--- a/aws/cluster/backend.tf
+++ b/aws/cluster/backend.tf
@@ -2,8 +2,8 @@ terraform {
   backend "s3" {
     bucket = "iac-state-bucket"
     key    = "aws/cluster/terraform.tfstate"
-    region = "us-east-1"
+    region = "eu-west-1"
     encrypt = true
-    dynamodb_table = "iac-state-lock"
+    lock_table = "iac-state-lock"
   }
 }

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -1,6 +1,6 @@
 variable "region" {
   description = "AWS region"
-  default     = "us-east-1"
+  default     = "eu-west-1"
 }
 
 variable "profile" {

--- a/aws/network/backend.tf
+++ b/aws/network/backend.tf
@@ -2,8 +2,8 @@ terraform {
   backend "s3" {
     bucket = "iac-state-bucket"
     key    = "aws/network/terraform.tfstate"
-    region = "us-east-1"
+    region = "eu-west-1"
     encrypt = true
-    dynamodb_table = "iac-state-lock"
+    lock_table = "iac-state-lock"
   }
 }

--- a/aws/network/variables.tf
+++ b/aws/network/variables.tf
@@ -1,6 +1,6 @@
 variable "region" {
   description = "AWS region"
-  default     = "us-east-1"
+  default     = "eu-west-1"
 }
 
 variable "profile" {


### PR DESCRIPTION
## Summary
- update AWS backend region to match bucket location
- switch S3 lock argument to `lock_table`
- default AWS region to `eu-west-1`
- ensure `GOOGLE_APPLICATION_CREDENTIALS` is set before `terraform init`

## Testing
- `terraform fmt -check -recursive` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850fa4bb2108331a207cdb5bb8dafca